### PR TITLE
added index-support for mk2

### DIFF
--- a/tasks/blink1.js
+++ b/tasks/blink1.js
@@ -30,7 +30,8 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('blink1', 'Blink a specific color on blink(1)', function() {
     var options = this.options({
       fadeMillis: 0,
-      turnOff: false
+      turnOff: false,
+      ledIndex: 0
     });
     var colors = [this.data.color || 'black'];
     colors = (_.isArray(this.data.colors)) ? this.data.colors : colors;
@@ -52,7 +53,7 @@ module.exports = function (grunt) {
       var c = new Color(color);
 
       if (options.fadeMillis > 0) {
-        blink1.fadeToRGB(options.fadeMillis, c.red(), c.green(), c.blue(), done);
+        blink1.fadeToRGB(options.fadeMillis, c.red(), c.green(), c.blue(), options.ledIndex, done);
       } else {
         blink1.setRGB(c.red(), c.green(), c.blue(), done);
       }


### PR DESCRIPTION
For MK2 devices, you can set an index (which side of the blink(1) should be the target).

From the [documentation](https://github.com/sandeepmistry/node-blink1/blob/master/README.md):

![mk2_index](https://cloud.githubusercontent.com/assets/912344/4720889/79bebc88-5934-11e4-89a1-940ae485a34a.png)

I added support for this index. My grunt-config now looks something like this:

```
    blink1: {
      bad: {
        colors: ['red', '#000', 'red'],
        options: {
          ledIndex: 2,
          fadeMillis: 100
        }
      }
    }
```

I can't test whats happening with mk1-devices, because i have none.
